### PR TITLE
PLAT-74 First step: Ability turn off gandi dns creation

### DIFF
--- a/v2-okd-cluster-gandi-dns/loadbalancer/main.tf
+++ b/v2-okd-cluster-gandi-dns/loadbalancer/main.tf
@@ -31,7 +31,9 @@ resource "openstack_compute_instance_v2" "k8s_lb" {
   }
 }
 
+
 resource "gandi_livedns_record" "lb_instance" {
+  count       = var.dns_enable
   zone        = var.domain_name
   name        = "lb-${var.cluster_name}"
   ttl         = 300
@@ -40,6 +42,7 @@ resource "gandi_livedns_record" "lb_instance" {
 }
 
 resource "gandi_livedns_record" "master_api" {
+  count       = var.dns_enable
   zone        = var.domain_name
   name        = "api.${var.cluster_name}"
   ttl         = 300
@@ -48,6 +51,7 @@ resource "gandi_livedns_record" "master_api" {
 }
 
 resource "gandi_livedns_record" "master_api_int" {
+  count       = var.dns_enable
   zone        = var.domain_name
   name        = "api-int.${var.cluster_name}"
   ttl         = 300
@@ -56,6 +60,7 @@ resource "gandi_livedns_record" "master_api_int" {
 }
 
 resource "gandi_livedns_record" "apps" {
+  count       = var.dns_enable
   zone        = var.domain_name
   name        = "*.apps.${var.cluster_name}"
 #  description = "apps record (DNS-RR)"

--- a/v2-okd-cluster-gandi-dns/loadbalancer/variables.tf
+++ b/v2-okd-cluster-gandi-dns/loadbalancer/variables.tf
@@ -1,3 +1,8 @@
+variable "dns_enable" {
+  type        = number
+  description = "0 if dns is disabled 1 if enabled"
+}
+
 variable "ssh_pubkey_path" {
   type        = string
   description = "Full path of the ssh public key file"

--- a/v2-okd-cluster-gandi-dns/main.tf
+++ b/v2-okd-cluster-gandi-dns/main.tf
@@ -1,6 +1,7 @@
 module "loadbalancer" {
   source                    = "./loadbalancer"
-  image_id             = data.openstack_images_image_v2.lb_image.id
+  dns_enable                = var.dns_enable
+  image_id                  = data.openstack_images_image_v2.lb_image.id
   cluster_name              = var.cluster_name
   domain_name               = var.domain_name
   flavor_name               = var.openstack_loadbalancer_flavor_name
@@ -23,6 +24,7 @@ module "bootstrap" {
 
 module "masters" {
   source          = "./masters"
+  dns_enable      = var.dns_enable
   base_image_id   = data.openstack_images_image_v2.base_image.id
   cluster_name    = var.cluster_name
   domain_name     = var.domain_name

--- a/v2-okd-cluster-gandi-dns/masters/main.tf
+++ b/v2-okd-cluster-gandi-dns/masters/main.tf
@@ -86,25 +86,23 @@ resource "openstack_compute_instance_v2" "master_conf" {
   }
 }
 
-#resource "gandi_livedns_record" "master_instances" {
-#  zone        = var.domain_name
-#  name        = "master-${count.index+1}-${var.cluster_name}"
-#  count       = var.instance_count
-#  ttl         = 300
-#  type        = "A"
-#  values      = [element(openstack_compute_instance_v2.master_conf.*.access_ip_v4,count.index)]
-#}
+locals {
+  dns_a_count   = var.dns_enable == 1 ? var.instance_count : 0
+  dns_srv_count = var.dns_enable == 1 ? 1 : 0
+}
 
-resource "gandi_livedns_record" "etcd_instances" {
+resource "gandi_livedns_record" "master_instances" {
   zone        = var.domain_name
-  name        = "etcd-${count.index+1}-${var.cluster_name}"
-  count       = var.instance_count
+  name        = "master-${count.index+1}-${var.cluster_name}"
+  count       = local.dns_a_count
   ttl         = 300
   type        = "A"
   values      = [element(openstack_compute_instance_v2.master_conf.*.access_ip_v4,count.index)]
 }
 
+
 resource "gandi_livedns_record" "etcd_srv" {
+  count       = local.dns_srv_count
   zone        = var.domain_name
   name        = "_etcd-server-ssl._tcp.${var.cluster_name}"
   ttl         = 300

--- a/v2-okd-cluster-gandi-dns/masters/variables.tf
+++ b/v2-okd-cluster-gandi-dns/masters/variables.tf
@@ -1,3 +1,7 @@
+variable "dns_enable" {
+  type        = number
+  description = "DNS provider"
+}
 variable "affinity" {
   type        = string
   description = "Affinity for masters. Choose between anti-affinity (hard) and soft-anti-affinity "

--- a/v2-okd-cluster-gandi-dns/variables.tf
+++ b/v2-okd-cluster-gandi-dns/variables.tf
@@ -1,3 +1,8 @@
+variable "dns_enable" {
+  type        = number
+  description = "DNS enable"
+}
+
 variable "lb_image_name" {
   type        = string
   description = "Image name for loadbalancer"


### PR DESCRIPTION
New variable $dns_enable that when 0 disables DNS record creation and leaves it ot the user to configure and when 1 re-enables the standard gandi-provider that was used from before. This solves the most urgent need which is the ability ot DIY-dns. The ansible terraform inventory script can be used directly as a datasource, based on terraform state file, to orchestrate DNS record creation using ansible. 