### PR TITLE
Apparently openstack doesn't seem to like '@' and '.' in keypair name…

### DIFF
--- a/v2-okd-cluster-gandi-dns/loadbalancer/main.tf
+++ b/v2-okd-cluster-gandi-dns/loadbalancer/main.tf
@@ -1,5 +1,5 @@
 resource "openstack_compute_keypair_v2" "kp" {
-  name       = "${var.cluster_name}-pubkey"
+  name       = replace("${var.cluster_name}-pubkey", "/[@.]/", "-")
   public_key = chomp(file(var.ssh_pubkey_path))
 }
 


### PR DESCRIPTION
…. Sanitizing keypair name.

Ref: https://specs.openstack.org/openstack/nova-specs/specs/xena/approved/allow-special-characters-in-keypair-name.html