### PR TITLE
get most recent base image

### DIFF
--- a/v2-okd-cluster-gandi-dns/main.tf
+++ b/v2-okd-cluster-gandi-dns/main.tf
@@ -62,8 +62,10 @@ module "topology" {
 
 data "openstack_images_image_v2" "base_image" {
   name = var.openstack_base_image_name
+  most_recent = true
 }
 
 data "openstack_images_image_v2" "lb_image" {
   name = var.lb_image_name
+  most_recent = true
 }


### PR DESCRIPTION
this is to be consistent with other `openstack_images_image_v2` data sources